### PR TITLE
Fix typing of the arguments of the TailwindMerge::merge function

### DIFF
--- a/src/TailwindMerge.php
+++ b/src/TailwindMerge.php
@@ -36,7 +36,7 @@ class TailwindMerge implements TailwindMergeContract
     }
 
     /**
-     * @param  array<array-key, string|array<array-key, string>>  ...$args
+     * @param  string|array<array-key, string|array<array-key, string>>  ...$args
      */
     public function merge(...$args): string
     {


### PR DESCRIPTION
The TailwindMerge::merge function can be used with just one string argument