### PR TITLE
Optimize Caching Logic

### DIFF
--- a/src/Support/ClassMap.php
+++ b/src/Support/ClassMap.php
@@ -18,7 +18,7 @@ class ClassMap
         $theme = $config['theme'];
         $prefix = $config['prefix'];
 
-        $classMap = new ClassPartObject();
+        $classMap = new ClassPartObject;
 
         $prefixedClassGroupEntries = self::getPrefixedClassGroupEntries(
             $config['classGroups'],
@@ -112,7 +112,7 @@ class ClassMap
 
         foreach (explode(self::CLASS_PART_SEPARATOR, $path) as $pathPart) {
             if (! isset($currentClassPartObject->nextPart[$pathPart])) {
-                $currentClassPartObject->nextPart[$pathPart] = new ClassPartObject();
+                $currentClassPartObject->nextPart[$pathPart] = new ClassPartObject;
             }
 
             $currentClassPartObject = $currentClassPartObject->nextPart[$pathPart];

--- a/src/Support/Stringable.php
+++ b/src/Support/Stringable.php
@@ -4,9 +4,7 @@ namespace TailwindMerge\Support;
 
 class Stringable
 {
-    public function __construct(protected string $value)
-    {
-    }
+    public function __construct(protected string $value) {}
 
     public function trim(string $characters = ' '): self
     {

--- a/src/TailwindMerge.php
+++ b/src/TailwindMerge.php
@@ -23,7 +23,7 @@ class TailwindMerge implements TailwindMergeContract
      */
     public static function factory(): Factory
     {
-        return new Factory();
+        return new Factory;
     }
 
     /**
@@ -32,8 +32,7 @@ class TailwindMerge implements TailwindMergeContract
     public function __construct(
         private readonly array $configuration,
         private readonly ?CacheInterface $cache = null,
-    ) {
-    }
+    ) {}
 
     /**
      * @param  string|array<array-key, string|array<array-key, string>>  ...$args
@@ -95,12 +94,9 @@ class TailwindMerge implements TailwindMergeContract
 
         $key = hash('xxh3', 'tailwind-merge-'.$input);
 
-        if ($this->cache->has($key)) {
-            $cachedValue = $this->cache->get($key);
-
-            if (is_string($cachedValue)) {
-                return $cachedValue;
-            }
+        $cachedValue = $this->cache->get($key);
+        if (is_string($cachedValue)) {
+            return $cachedValue;
         }
 
         $mergedClasses = $callback($input);

--- a/src/ValueObjects/ClassPartObject.php
+++ b/src/ValueObjects/ClassPartObject.php
@@ -12,6 +12,5 @@ class ClassPartObject
         public array $nextPart = [],
         public array $validators = [],
         public ?string $classGroupId = null,
-    ) {
-    }
+    ) {}
 }

--- a/src/ValueObjects/ClassValidatorObject.php
+++ b/src/ValueObjects/ClassValidatorObject.php
@@ -9,6 +9,5 @@ class ClassValidatorObject
     public function __construct(
         public string $classGroupId,
         public Closure $validator,
-    ) {
-    }
+    ) {}
 }

--- a/src/ValueObjects/ThemeGetter.php
+++ b/src/ValueObjects/ThemeGetter.php
@@ -6,8 +6,7 @@ class ThemeGetter
 {
     public function __construct(
         public string $key
-    ) {
-    }
+    ) {}
 
     /**
      * @param  array<string, array<string, mixed>>  $theme

--- a/tests/Feature/CacheTest.php
+++ b/tests/Feature/CacheTest.php
@@ -4,7 +4,7 @@ use Psr\SimpleCache\CacheInterface;
 use TailwindMerge\TailwindMerge;
 
 it('does cache the result', function () {
-    $cache = new FakeCache();
+    $cache = new FakeCache;
 
     $twMerge = TailwindMerge::factory()->withCache($cache)->make();
 


### PR DESCRIPTION
Hi there! 👋

I'm excited to contribute to the tailwind-merge-php package. I've found an opportunity to optimize the caching logic, which should improve performance slightly. It cuts the number of cache calls in half.

## What I discovered:
- The current caching logic uses a two-step process: first checking if the key exists in the cache, then retrieving the value.
- This approach results in unnecessary method calls when the key exists in the cache.

## What I did to fix it:
1. Simplified the caching logic by directly attempting to retrieve the value from the cache.
2. If the retrieved value is not a string (including null for non-existent keys), we simply continue with the existing logic.
3. This change eliminates the need for a separate `has()` check, potentially improving performance.

Here's the exact change:

**Before**
```php
if ($this->cache->has($key)) {
    $cachedValue = $this->cache->get($key);

    if (is_string($cachedValue)) {
        return $cachedValue;
    }
}
```

**After**
```php
$cachedValue = $this->cache->get($key);
if (is_string($cachedValue)) {
    return $cachedValue;
}
```
I hope this helps improve the package! Let me know if you'd like me to explain anything further or make any changes.

Thanks for considering my contribution! 😊